### PR TITLE
Removes date from banner as it adds unnecessary commits when rebuilding a page locally.

### DIFF
--- a/cfpb-banner.txt
+++ b/cfpb-banner.txt
@@ -10,7 +10,7 @@
  *                   $$
  *                   $$
  *                   ""
- *  <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("yyyy-mm-dd") %>
+ *  <%= pkg.name %> - v<%= pkg.version %>
  *  <%= pkg.homepage %>
  *  A public domain work of the <%= pkg.author.name %>
  */


### PR DESCRIPTION
It's annoying that files using the banner are marked as modified in git because it has the current date built into it.
