### PR TITLE
Add variable override for component development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,26 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## 1.0.2 - 2015-06-01
+
+### Added
+- Added `modifyVars` option to Less config so that component contributors paths
+  for importing other Less files will be correct (after each component is
+  updated to use the `@baseurl` variable in its imports).
+
+
+## 1.0.1 - 2015-06-01
+
+### Fixed
+- Failing tests at 1.0.0.
+
+
 ## 1.0.0 - 2015-06-01
 
 ### Changed
 - Removed `concat` and `bower` tasks.
+
 
 ## 0.3.1 - 2015-01-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-grunt-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Common Grunt tasks for Capital Framework components.",
   "keywords": [
     "capital-framework",

--- a/tasks/options/less.js
+++ b/tasks/options/less.js
@@ -5,7 +5,10 @@ module.exports = {
     options: {
       paths: grunt.file.expand('src/vendor/**'),
       sourceMap: true,
-      sourceMapRootpath: '/'
+      sourceMapRootpath: '/',
+      modifyVars: {
+        baseurl: '',
+      }
     },
     files: {
       'demo/static/css/main.css': [


### PR DESCRIPTION
This is being added to fix an issue with local development of Capital Framework components.

Currently, if you are a component developer, and you clone each component into the same parent directory on your filesystem, then when you run `grunt less` on a component project, Less will import the versions of its CF component dependencies from your other local clones, _not_ from the dependencies installed by Bower in that component's `src/vendor/` folder.

This is because that at the top of a component's Less file, its import paths are prepended with `../../`. This is so that CF components can be used in a project without a build tool, but using pure `lessc` with `@import` statements.

We have the `paths` option in the Less task set to `src/vendor/**`, but if found at the exact location given in the import (i.e., the `../../` location), that takes precedence over a version located in the paths specified in the `paths` option.

This means that if you develop lots of CF components locally, and you store them all in the same folder on your computer (which seems likely), you're never getting the actual dependencies downloaded via Bower when you compile a component, you're getting whatever you last downloaded in your local clone of each of those dependencies.

Still with me?

The fix for this begins with this PR, which adds a `modifyVars` option to the common component Less task. This overrides a variable called `@baseurl` whenever you're compiling Less using this Grunt task. Each component will need to add this variable into their `@import` statements at the top of their `cf-whatever.less` files, like so:

```less
@baseurl: '../../';
@import '@{baseurl}cf-core/src/cf-core.less;
```

By doing so, the import will continue to work correctly for those that don't build with a build tool, and when you are building a component with the Less task given by cf-grunt-config, it'll find it in the location specified in the `paths` option, instead of your clone of that component.

So, after this is merged, each component will need to be updated to use that baseurl variable and the new version of cf-grunt-config.

I know that's really confusing, so let me know if you have questions.

- @contolini