### PR TITLE
Add @cf-icon-path var to modifyVars in Less task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
-## 1.0.2 - 2015-06-01
+## 1.0.3 - 2015-10-13
+
+### Added
+- Added `@cf-icon-path` to Less's `modifyVars` option to restore correct path
+  for cf-icons font files when compiling a component's docs.
+
+
+## 1.0.2 - 2015-10-13
 
 ### Added
 - Added `modifyVars` option to Less config so that component contributors paths

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-grunt-config",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Common Grunt tasks for Capital Framework components.",
   "keywords": [
     "capital-framework",

--- a/tasks/options/less.js
+++ b/tasks/options/less.js
@@ -8,7 +8,7 @@ module.exports = {
       sourceMapRootpath: '/',
       modifyVars: {
         baseurl: '',
-        'cf-icon-path': '../'
+        'cf-icon-path': '\'../fonts\''
       }
     },
     files: {

--- a/tasks/options/less.js
+++ b/tasks/options/less.js
@@ -8,6 +8,7 @@ module.exports = {
       sourceMapRootpath: '/',
       modifyVars: {
         baseurl: '',
+        'cf-icon-path': '../'
       }
     },
     files: {


### PR DESCRIPTION
As components do not have their own cf-vars-overrides for their doc builds,
adding this variable override to the Less task will restore the correct
path to cf-icons font files in Docs and Demo.